### PR TITLE
Fix: Cannot save public and provided graphs as copy

### DIFF
--- a/src/app/api/(routes)/graphs/update/route.ts
+++ b/src/app/api/(routes)/graphs/update/route.ts
@@ -37,11 +37,10 @@ export async function POST(req: Request) {
       }
 
       const saved = res.data()!;
-      if (!saved.user_id /* universal */) {
+      if (saved.public || !saved.user_id /* universal */) {
         const doc = graphs.doc();
         graphId = doc.id;
         name = `${saved.name}_copy`;
-
         // create a user-owned copy from universal graph
         doc.create({ user_id, ...data, name, updated_at });
       } else {

--- a/src/app/features/chat/components/dialog-flows/flow-graph.tsx
+++ b/src/app/features/chat/components/dialog-flows/flow-graph.tsx
@@ -68,13 +68,6 @@ import NodeContextMenu from "./node-context-menu";
 import NodeSelectionMenu, {
   type NodeSelectionMenuHandle,
 } from "./node-selection-menu";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { useLayoutStore } from "./layout-store";
 import Share from "./share";
 import Controls from "./controls";
@@ -88,6 +81,7 @@ import {
   DialogClose,
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
+
 
 function Toolbar({ onAdd }: { onAdd(): void }) {
   const viewport = useViewport();
@@ -497,8 +491,6 @@ function FlowEditor({ setOpen }: FlowEditorProps) {
     publicGraph,
     setPublicGraph,
     lastSaved,
-    model,
-    setModel,
   } = useDialogFlowStore();
   const {
     isOutdated,
@@ -773,29 +765,33 @@ function FlowEditor({ setOpen }: FlowEditorProps) {
               </Tooltip>
             )}
 
-            {origin !== "universal" && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    type="button"
-                    aria-label="Save Graph"
-                    onClick={saveCurrentGraph}
-                    className="size-9 border-neutral-200 hover:border-neutral-300 hover:bg-neutral-200 p-0"
-                  >
-                    <Image
-                      src="/assets/icons/save-cloud.svg"
-                      alt="save"
-                      width={16}
-                      height={16}
-                    />
-                  </Button>
-                </TooltipTrigger>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  type="button"
+                  aria-label="Save Graph"
+                  onClick={saveCurrentGraph}
+                  className="size-9 border-neutral-200 hover:border-neutral-300 hover:bg-neutral-200 p-0"
+                >
+                  <Image
+                    src="/assets/icons/save-cloud.svg"
+                    alt="save"
+                    width={16}
+                    height={16}
+                  />
+                </Button>
+              </TooltipTrigger>
+              {origin !== "universal" ? (
                 <TooltipContent side="top" align="end" sideOffset={5}>
                   Save the current graph.
                 </TooltipContent>
-              </Tooltip>
-            )}
+              ) : (
+                <TooltipContent side="top" align="end" sideOffset={5}>
+                  Save the current graph as a copy.
+                </TooltipContent>
+              )}
+            </Tooltip>
 
             <Tooltip>
               <TooltipTrigger asChild>


### PR DESCRIPTION
Providing a fix for 
![image](https://github.com/user-attachments/assets/66505b4b-3bb1-44f3-aed5-270d5d6123f5)
when saving public or provided graphs as copy

Note that the issue mentioned in #162 will remain as it is out of scope and potentially require a big change to fix.